### PR TITLE
修复migration一处bug及修改migration的version生成

### DIFF
--- a/src/Console/SeedRun.php
+++ b/src/Console/SeedRun.php
@@ -137,13 +137,12 @@ class Migration extends Manager
             $migrations = array();
 
             $version = date('Ymd');
-            $versionIncrementSeed = mt_rand(1000, 9999 - count($phpFiles));
 
-            foreach ($phpFiles as $filePath) {
+            foreach ($phpFiles as $index => $filePath) {
                 $class = pathinfo($filePath, PATHINFO_FILENAME);
                 $fileNames[$class] = basename($filePath);
                 require_once $filePath;
-                $migration = new $class($version.(++$versionIncrementSeed), $this->getInput(), $this->getOutput());
+                $migration = new $class($version . str_pad($index, 4, '0', STR_PAD_LEFT), $this->getInput(), $this->getOutput());
 
                 if (!($migration instanceof AbstractMigration)) {
                     throw new \InvalidArgumentException(sprintf(

--- a/src/Model/Migration.php
+++ b/src/Model/Migration.php
@@ -11,6 +11,7 @@ namespace FastD\Model;
 
 use Phinx\Db\Table;
 use Phinx\Migration\AbstractMigration;
+use Phinx\Db\Table\Column;
 
 /**
  * Class Migration.
@@ -21,12 +22,24 @@ abstract class Migration extends AbstractMigration
     {
         $table = $this->setUp();
         if (!$table->exists()) {
-            if (!$table->hasColumn('created')) {
-                $table->addColumn('created', 'datetime');
-            }
-            if (!$table->hasColumn('updated')) {
-                $table->addColumn('updated', 'datetime');
-            }
+
+            $hasCreatedColumn = $hasUpdatedColumn = false;
+            array_map(
+                function (Column $column) use (&$hasCreatedColumn, &$hasUpdatedColumn) {
+                    if ('created' === $column->getName()) {
+                        $hasCreatedColumn = true;
+                        return;
+                    }
+                    if ('updated' === $column->getName()) {
+                        $hasUpdatedColumn = true;
+                        return;
+                    }
+                },
+                $table->getPendingColumns()
+            );
+            !$hasCreatedColumn && $table->addColumn('created', 'datetime');
+            !$hasUpdatedColumn && $table->addColumn('updated', 'datetime');
+
             $table->create();
         }
         $this->dataSet($table);


### PR DESCRIPTION
原先 `FastD\Model\Migration` 中的 `change()` 方法中,如果表不存在时, 使用的 `Table::hasColumn()` 是向数据库查询表字段信息,

```
#class: Phinx\Db\Adapter\MysqlAdapter

public function hasColumn($tableName, $columnName)
    {
        $rows = $this->fetchAll(sprintf('SHOW COLUMNS FROM %s', $this->quoteTableName($tableName)));
        ...
    }
```
所以就报错了