### PR TITLE
优化异常日志处理

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -175,9 +175,16 @@ class Application extends Container
      */
     public function handleException(Exception $e)
     {
-        $this->add('exception', $e);
+        try {
+            $trace = call_user_func(config()->get('exception.log'), $e);
+        } catch (Exception $exception) {
+            $trace = [
+                'original' => explode("\n", $e->getTraceAsString()),
+                'handler'  => explode("\n", $exception->getTraceAsString()),
+            ];
+        }
 
-        logger()->log(Logger::ERROR, $e->getMessage(), call_user_func(config()->get('exception.log'), $e));
+        logger()->log(Logger::ERROR, $e->getMessage(), $trace);
     }
 
     /**

--- a/src/Application.php
+++ b/src/Application.php
@@ -128,7 +128,7 @@ class Application extends Container
 
     protected function registerExceptionHandler()
     {
-        error_reporting(config()->get('error_reporting_level', -1));
+        error_reporting(-1);
 
         set_exception_handler([$this, 'handleException']);
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -128,7 +128,7 @@ class Application extends Container
 
     protected function registerExceptionHandler()
     {
-        error_reporting(-1);
+        error_reporting(config()->get('error_reporting_level', -1));
 
         set_exception_handler([$this, 'handleException']);
 
@@ -184,6 +184,9 @@ class Application extends Container
             ];
         }
 
+        /**
+         * TODO 如果在是在 console, 并且在 bootstrap 中发生异常, 将只会保存日志而没有抛出任何异常
+         */
         logger()->log(Logger::ERROR, $e->getMessage(), $trace);
     }
 

--- a/src/Console.php
+++ b/src/Console.php
@@ -16,6 +16,9 @@ use FastD\Console\RouteDump;
 use FastD\Console\SeedCreate;
 use FastD\Console\SeedRun;
 use Symfony\Component\Console\Application as Symfony;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Debug\Exception\FatalThrowableError;
 
 /**
  * Class AppConsole.
@@ -58,5 +61,18 @@ class Console extends Symfony
                 $this->add(new $command());
             }
         }
+    }
+
+    public function doRun(InputInterface $input, OutputInterface $output)
+    {
+        try {
+            return parent::doRun($input, $output);
+        } catch (\Exception $exception) {
+            app()->handleException($exception);
+        } catch (\Throwable $exception) {
+            app()->handleException(new FatalThrowableError($exception));
+        }
+
+        throw $exception;
     }
 }

--- a/src/Logger/ErrorHandler.php
+++ b/src/Logger/ErrorHandler.php
@@ -18,7 +18,6 @@ class ErrorHandler extends HandlerAbstract
     {
         return [
             'ip' => get_local_ip(),
-            'status' => response()->getStatusCode(),
             'get' => request()->getQueryParams(),
             'post' => request()->getParsedBody(),
             'msg' => exception()->getMessage(),

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -63,7 +63,7 @@
 
         public function testHandleException()
         {
-            $response = $this->app->handleException(new LogicException('handle exception'));
+            $response = $this->app->renderException(new LogicException('handle exception'));
             $this->app->add('response', $response);
             $this->app->add('request', new \FastD\Http\ServerRequest('GET', '/'));
             $this->app->shutdown(new \FastD\Http\ServerRequest('GET', '/'), $response);

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -48,6 +48,8 @@
             $request = $this->request('GET', '/not/found');
             $response = $this->app->handleRequest($request);
             $this->assertEquals(404, $response->getStatusCode());
+            $this->assertTrue(file_exists(app()->getPath().'/runtime/logs/error.log'));
+            unlink(app()->getPath().'/runtime/logs/error.log');
         }
 
         public function testCacheServiceProvider()
@@ -63,7 +65,9 @@
 
         public function testHandleException()
         {
-            $response = $this->app->renderException(new LogicException('handle exception'));
+            $exception = new LogicException('handle exception');
+            $this->app->handleException($exception);
+            $response = $this->app->renderException($exception);
             $this->app->add('response', $response);
             $this->app->add('request', new \FastD\Http\ServerRequest('GET', '/'));
             $this->app->shutdown(new \FastD\Http\ServerRequest('GET', '/'), $response);

--- a/tests/MinimalTest.php
+++ b/tests/MinimalTest.php
@@ -57,7 +57,9 @@
 
         public function testHandleException()
         {
-            $response = $this->app->renderException(new LogicException('handle exception'));
+            $exception = new LogicException('handle exception');
+            $this->app->handleException($exception);
+            $response = $this->app->renderException($exception);
             $this->equalsStatus($response, 502);
             $this->assertFalse(file_exists(app()->getPath().'/runtime/logs/error.log'));
         }

--- a/tests/MinimalTest.php
+++ b/tests/MinimalTest.php
@@ -57,7 +57,7 @@
 
         public function testHandleException()
         {
-            $response = $this->app->handleException(new LogicException('handle exception'));
+            $response = $this->app->renderException(new LogicException('handle exception'));
             $this->equalsStatus($response, 502);
             $this->assertFalse(file_exists(app()->getPath().'/runtime/logs/error.log'));
         }

--- a/tests/NoCacheTest.php
+++ b/tests/NoCacheTest.php
@@ -65,7 +65,7 @@
 
         public function testHandleException()
         {
-            $response = $this->app->handleException(new LogicException('handle exception'));
+            $response = $this->app->renderException(new LogicException('handle exception'));
             $this->app->add('response', $response);
             $this->app->add('request', new \FastD\Http\ServerRequest('GET', '/'));
             $this->app->shutdown(new \FastD\Http\ServerRequest('GET', '/'), $response);

--- a/tests/NoCacheTest.php
+++ b/tests/NoCacheTest.php
@@ -47,6 +47,8 @@
             $request = $this->request('GET', '/not/found');
             $response = $this->app->handleRequest($request);
             $this->assertEquals(404, $response->getStatusCode());
+            $this->assertTrue(file_exists(app()->getPath().'/runtime/logs/error.log'));
+            unlink(app()->getPath().'/runtime/logs/error.log');
         }
 
         /**
@@ -65,7 +67,9 @@
 
         public function testHandleException()
         {
-            $response = $this->app->renderException(new LogicException('handle exception'));
+            $exception = new LogicException('handle exception');
+            $this->app->handleException($exception);
+            $response = $this->app->renderException($exception);
             $this->app->add('response', $response);
             $this->app->add('request', new \FastD\Http\ServerRequest('GET', '/'));
             $this->app->shutdown(new \FastD\Http\ServerRequest('GET', '/'), $response);

--- a/tests/NoLoggerTest.php
+++ b/tests/NoLoggerTest.php
@@ -66,7 +66,7 @@
 
         public function testHandleException()
         {
-            $response = $this->app->handleException(new LogicException('handle exception'));
+            $response = $this->app->renderException(new LogicException('handle exception'));
             $this->equalsStatus($response, 502);
             $this->assertFalse(file_exists(app()->getPath().'/runtime/logs/error.log'));
         }

--- a/tests/NoLoggerTest.php
+++ b/tests/NoLoggerTest.php
@@ -48,6 +48,7 @@
             $request = $this->request('GET', '/not/found');
             $response = $this->app->handleRequest($request);
             $this->assertEquals(404, $response->getStatusCode());
+            $this->assertFalse(file_exists(app()->getPath().'/runtime/logs/error.log'));
         }
 
         public function testCacheServiceProvider()

--- a/tests/NotDBTest.php
+++ b/tests/NotDBTest.php
@@ -65,7 +65,7 @@
 
         public function testHandleException()
         {
-            $response = $this->app->handleException(new LogicException('handle exception'));
+            $response = $this->app->renderException(new LogicException('handle exception'));
             $this->app->add('response', $response);
             $this->app->add('request', new \FastD\Http\ServerRequest('GET', '/'));
             $this->app->shutdown(new \FastD\Http\ServerRequest('GET', '/'), $response);

--- a/tests/NotDBTest.php
+++ b/tests/NotDBTest.php
@@ -47,6 +47,8 @@
             $request = $this->request('GET', '/not/found');
             $response = $this->app->handleRequest($request);
             $this->assertEquals(404, $response->getStatusCode());
+            $this->assertTrue(file_exists(app()->getPath().'/runtime/logs/error.log'));
+            unlink(app()->getPath().'/runtime/logs/error.log');
         }
 
         /**
@@ -65,7 +67,9 @@
 
         public function testHandleException()
         {
-            $response = $this->app->renderException(new LogicException('handle exception'));
+            $exception = new LogicException('handle exception');
+            $this->app->handleException($exception);
+            $response = $this->app->renderException($exception);
             $this->app->add('response', $response);
             $this->app->add('request', new \FastD\Http\ServerRequest('GET', '/'));
             $this->app->shutdown(new \FastD\Http\ServerRequest('GET', '/'), $response);

--- a/tests/app/default/config/app.php
+++ b/tests/app/default/config/app.php
@@ -17,8 +17,8 @@ return [
      * Application logger
      */
     'log' => [
-        [\FastD\Logger\AccessHandler::class, 'info.log'],
-        [\FastD\Logger\ErrorHandler::class, 'error.log', \FastD\Logger\Logger::ERROR],
+        [\Monolog\Handler\StreamHandler::class, 'info.log'],
+        [\Monolog\Handler\StreamHandler::class, 'error.log', \FastD\Logger\Logger::ERROR],
     ],
 
     /*
@@ -26,6 +26,15 @@ return [
      */
     'exception' => [
         'response' => function (Exception $e) {
+            return [
+                'msg' => $e->getMessage(),
+                'code' => $e->getCode(),
+                'file' => $e->getFile(),
+                'line' => $e->getLine(),
+                'trace' => explode("\n", $e->getTraceAsString()),
+            ];
+        },
+        'log' => function (Exception $e) {
             return [
                 'msg' => $e->getMessage(),
                 'code' => $e->getCode(),

--- a/tests/app/minimal/config/app.php
+++ b/tests/app/minimal/config/app.php
@@ -23,6 +23,15 @@ return [
                 'code' => $e->getCode(),
             ];
         },
+        'log' => function (Exception $e) {
+            return [
+                'msg' => $e->getMessage(),
+                'code' => $e->getCode(),
+                'file' => $e->getFile(),
+                'line' => $e->getLine(),
+                'trace' => explode("\n", $e->getTraceAsString()),
+            ];
+        },
     ],
 
     /*

--- a/tests/app/no-cache/config/app.php
+++ b/tests/app/no-cache/config/app.php
@@ -34,6 +34,15 @@ return [
                 'trace' => explode("\n", $e->getTraceAsString()),
             ];
         },
+        'log' => function (Exception $e) {
+            return [
+                'msg' => $e->getMessage(),
+                'code' => $e->getCode(),
+                'file' => $e->getFile(),
+                'line' => $e->getLine(),
+                'trace' => explode("\n", $e->getTraceAsString()),
+            ];
+        },
     ],
 
     /*

--- a/tests/app/no-database/config/app.php
+++ b/tests/app/no-database/config/app.php
@@ -34,6 +34,15 @@ return [
                 'trace' => explode("\n", $e->getTraceAsString()),
             ];
         },
+        'log' => function (Exception $e) {
+            return [
+                'msg' => $e->getMessage(),
+                'code' => $e->getCode(),
+                'file' => $e->getFile(),
+                'line' => $e->getLine(),
+                'trace' => explode("\n", $e->getTraceAsString()),
+            ];
+        },
     ],
 
     /*

--- a/tests/app/no-logger/config/app.php
+++ b/tests/app/no-logger/config/app.php
@@ -32,6 +32,15 @@ return [
                 'trace' => explode("\n", $e->getTraceAsString()),
             ];
         },
+        'log' => function (Exception $e) {
+            return [
+                'msg' => $e->getMessage(),
+                'code' => $e->getCode(),
+                'file' => $e->getFile(),
+                'line' => $e->getLine(),
+                'trace' => explode("\n", $e->getTraceAsString()),
+            ];
+        },
     ],
 
     /*


### PR DESCRIPTION
- 日志转为只针对异常
- 强制使用最低的错误报告级别, 杜绝隐患
- 增加对 console 的异常日志
- 移除访问日志功能, 可通过后置中间件实现