### PR TITLE
unset exception only when exists

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -222,7 +222,9 @@ class Application extends Container
     {
         $this->offsetUnset('request');
         $this->offsetUnset('response');
-        $this->offsetUnset('exception');
+        if ($this->offsetExists('exception')) {
+            $this->offsetUnset('exception');
+        }
         unset($request, $response);
 
         return 0;


### PR DESCRIPTION
exception is set when handleException() being called.

It will cause a Fatal error if no exception thrown from app.

ERROR   zm_deactivate_swoole (ERROR 503): Fatal error: Uncaught ErrorException: Undefined index: exception in /Users/nishurong/PhpstormProjects/php-workspace/xueron/fastD/src/Application.php:225
Stack trace:
